### PR TITLE
chore: Add missing required package.json fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "o-utils",
+  "version": "0.0.0",
   "devDependencies": {
     "babel-loader": "^5.3.2",
     "babel-runtime": "5.8.25",


### PR DESCRIPTION
Adding missing required package.json fields so that tooling such as Yarn can handle the module correctly.