### PR TITLE
Jest readability

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,6 @@
 		".gitignore",
 		".travis.yml",
 		"karma.conf.js",
-		"package.json",
 		"test"
 	],
 	"dependencies": {}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "proclaim": "^3.4.1"
   },
   "private": true,
+  "main": "main.js",
   "scripts": {
     "test": "./node_modules/karma/bin/karma start karma.conf.js"
   }


### PR DESCRIPTION
Stop bower from ignoring package.json on install and set the `main` field in order to allow `jest` to load the package.

More details at: https://github.com/Financial-Times/di2-front-end-render/issues/901