### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,8 +1,7 @@
-/*global describe,beforeEach,afterEach,it*/
+/* eslint-env mocha */
+/* global proclaim sinon */
 
 import * as Utils from './../main';
-import sinon from 'sinon/pkg/sinon';
-import proclaim from 'proclaim';
 
 describe("getIndex()", function() {
 


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.