### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as Utils from './../main';
+import * as Utils from './../main.js';
 
 describe("getIndex()", function() {
 


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing